### PR TITLE
Fix project context fetch loop

### DIFF
--- a/src/contexts/ProjectContext.jsx
+++ b/src/contexts/ProjectContext.jsx
@@ -14,30 +14,37 @@ export const ProjectProvider = ({ children }) => {
 
   useEffect(() => {
     const fetchProjects = async () => {
-      if (user && projects.length === 0) {
-        setIsLoading(true);
-        const { data: projectData, error: projectError } = await supabase
-          .from('projects')
-          .select('id, name')
-          .order('created_at', { ascending: true });
-
-        if (projectError) {
-          console.error('Error fetching projects:', projectError);
-          setProjects([]);
-        } else {
-          setProjects(projectData);
-          const currentSelectedProject = localStorage.getItem('taskDashboard_selectedProject');
-          if (currentSelectedProject && projectData.find(p => p.id.toString() === currentSelectedProject)) {
-            setSelectedProject(currentSelectedProject);
-          } else if (projectData.length > 0) {
-            setSelectedProject(projectData[0].id);
-          }
-        }
+      if (!user) {
+        setProjects([]);
+        setSelectedProject(null);
         setIsLoading(false);
+        return;
       }
+
+      setIsLoading(true);
+      const { data: projectData, error: projectError } = await supabase
+        .from('projects')
+        .select('id, name')
+        .order('created_at', { ascending: true });
+
+      if (projectError) {
+        console.error('Error fetching projects:', projectError);
+        setProjects([]);
+      } else {
+        setProjects(projectData);
+        const currentSelectedProject = localStorage.getItem('taskDashboard_selectedProject');
+        if (currentSelectedProject && projectData.find(p => p.id.toString() === currentSelectedProject)) {
+          setSelectedProject(currentSelectedProject);
+        } else if (projectData.length > 0) {
+          setSelectedProject(projectData[0].id);
+        } else {
+          setSelectedProject(null);
+        }
+      }
+      setIsLoading(false);
     };
     fetchProjects();
-  }, [user, projects]);
+  }, [user]);
 
   useEffect(() => {
     if (selectedProject) {


### PR DESCRIPTION
## Summary
- avoid infinite re-fetching of projects by only watching the user
- clear projects and selection when no user

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_687eccf7a6648322a0916e6858f75698

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved project loading and selection behavior for a smoother user experience, especially when switching users or handling empty project lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->