### PR TITLE
Fix ErrorBoundary width class typo

### DIFF
--- a/src/components/ErrorBoundary.jsx
+++ b/src/components/ErrorBoundary.jsx
@@ -32,7 +32,7 @@ class ErrorBoundary extends React.Component {
             </div>
             <div className="flex flex-col gap-1 text-center">
               <h1 className="text-2xl font-medium text-neutral-800">Something went wrong</h1>
-              <p className="text-neutral-600 text-base w w-8/12 mx-auto">We encountered an unexpected error while processing your request.</p>
+              <p className="text-neutral-600 text-base w-8/12 mx-auto">We encountered an unexpected error while processing your request.</p>
             </div>
             <div className="flex justify-center items-center mt-6">
               <button


### PR DESCRIPTION
## Summary
- fix duplicated `w` width class in ErrorBoundary component

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_687ed015b70c8322bacfa61cc9a834c4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Removed a duplicate style class from the error message display for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->